### PR TITLE
specify dependencies as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/Fullscreen/angular-asset-path/issues"
   },
   "homepage": "https://github.com/Fullscreen/angular-asset-path",
-  "dependencies": {
+  "devDependencies": {
     "gulp": "^3.8.8",
     "gulp-ng-annotate": "^0.3.1",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
Hey man! This project is just what I was looking for, thank you! We use npm in our shop, so it would be nice if this was registered on npm registry, but if not, I can still have it pointing at your repo, but would like to have not pull down the dev dependencies as well. Thanks again!